### PR TITLE
Add user group filtering for environment visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Simply search for the `Umbraco.Community.ClientDrawer` NuGet package and add it 
         "BaseUrl": "https://preview.samplewebsite.com",
         "AlternativeHostnames": [ "samplewebsite-preview.azurewebsites.net" ],
         "IconClass": "icon-mindmap",
-        "UserGroups": "admin,editor"
+        "UserGroups": [ "admin", "editor" ]
       },
       {
         "Name": "Staging",
@@ -115,10 +115,10 @@ Simply search for the `Umbraco.Community.ClientDrawer` NuGet package and add it 
 | DisableUmbracoUrl          	| `bool` 	| `false`  	| | 1.0.0 |
 | AlternativeHostnames          	| `string[]` 	| `null`  	| `["test.samplewebsite.com", "nocache.samplewebsite.com"]` | 1.0.0 |
 | IconClass          	| `string` 	| `"icon-globe"`  	| `"icon-mindmap"` | 1.0.0 |
-| UserGroups          	| `string` 	| `null`  	| `"admin,editor"` or `"admin"` | 17.0.1 |
+| UserGroups          	| `string[]` 	| `null`  	| `["admin", "editor"]` or `["admin"]` | 17.1.0 |
 
 **Note on UserGroups**: 
-- Use comma-separated user group aliases (e.g., `"admin,editor,writer"`)
+- Use a string array of user group aliases (e.g., `["admin", "editor", "writer"]`)
 - If omitted or `null`, the environment is accessible to all backoffice users
 - If specified, only users belonging to one of the listed groups can see that environment
 - If a user has no access to any environments, Client Drawer is automatically hidden
@@ -180,7 +180,7 @@ If you're embedding this file as a resource within a DLL, also use the `ClientDr
 
 |Version    |Change Type    |Description     |
 |-----------|---------------|--------------- |
-|17.0.1     |Feature        |Added UserGroups property to Environment configuration for per-environment access control. Client Drawer automatically hides when users have no accessible environments.|
+|17.1.0     |Feature        |Added UserGroups property to Environment configuration for per-environment access control. Client Drawer automatically hides when users have no accessible environments.|
 |17.0.0     |New release    |Umbraco v17 compatibility|
 |15.0.0.1   |Fix            |Resolved an issue with the Client Drawer Core dependency on first install. Also, Removal of some unnecessary files, thanks [Jeavon](https://github.com/Jeavon)!|
 |15.0.0     |New release    |Compatibility with Umbraco v15|

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
     - Website URL
     - Umbraco CMS Url - assumes 'Website URL' + '/umbraco/' by default, but can be manually set if under a different URL. You can disable this all together should you wish.
     - Ability to set additional hostnames
+    - **User Group Permissions** - optionally restrict access to specific environments based on user group membership
     - If the current URL hostname matches the hostname of your Website URL, Umbraco CMS URL or additional hostnames then it will be flagged as 'Current' to clearly identify which environment an editor is on.
 - A client friendly **change log** to share recent developments on the website or platform.
     - Based on your own XML file held within the file system, or as a resource item within an assembly of your choice. 
@@ -50,7 +51,8 @@ Simply search for the `Umbraco.Community.ClientDrawer` NuGet package and add it 
         "Name": "Preview",
         "BaseUrl": "https://preview.samplewebsite.com",
         "AlternativeHostnames": [ "samplewebsite-preview.azurewebsites.net" ],
-        "IconClass": "icon-mindmap"
+        "IconClass": "icon-mindmap",
+        "UserGroups": "admin,editor"
       },
       {
         "Name": "Staging",
@@ -113,6 +115,14 @@ Simply search for the `Umbraco.Community.ClientDrawer` NuGet package and add it 
 | DisableUmbracoUrl          	| `bool` 	| `false`  	| | 1.0.0 |
 | AlternativeHostnames          	| `string[]` 	| `null`  	| `["test.samplewebsite.com", "nocache.samplewebsite.com"]` | 1.0.0 |
 | IconClass          	| `string` 	| `"icon-globe"`  	| `"icon-mindmap"` | 1.0.0 |
+| UserGroups          	| `string` 	| `null`  	| `"admin,editor"` or `"admin"` | 17.0.1 |
+
+**Note on UserGroups**: 
+- Use comma-separated user group aliases (e.g., `"admin,editor,writer"`)
+- If omitted or `null`, the environment is accessible to all backoffice users
+- If specified, only users belonging to one of the listed groups can see that environment
+- If a user has no access to any environments, Client Drawer is automatically hidden
+- Group matching is case-insensitive
 
 ### `ChangeLog`
 
@@ -170,6 +180,7 @@ If you're embedding this file as a resource within a DLL, also use the `ClientDr
 
 |Version    |Change Type    |Description     |
 |-----------|---------------|--------------- |
+|17.0.1     |Feature        |Added UserGroups property to Environment configuration for per-environment access control. Client Drawer automatically hides when users have no accessible environments.|
 |17.0.0     |New release    |Umbraco v17 compatibility|
 |15.0.0.1   |Fix            |Resolved an issue with the Client Drawer Core dependency on first install. Also, Removal of some unnecessary files, thanks [Jeavon](https://github.com/Jeavon)!|
 |15.0.0     |New release    |Compatibility with Umbraco v15|

--- a/src/ClientDrawer.Bellissima/ClientDrawer.Bellissima.csproj
+++ b/src/ClientDrawer.Bellissima/ClientDrawer.Bellissima.csproj
@@ -16,8 +16,8 @@
 		<Description>An Umbraco package for providing your clients a small toolbox of useful links and information. If your website is one of many sites based on a shared platform then this package is perfect for you.</Description>
 		<PackageTags>umbraco;umbraco-marketplace;ClientDrawer;Client;Drawer;Changelog;Change;Log;Logs;Environment;Environments;HeaderApp</PackageTags>
 		<GeneratePackageOnBuild>False</GeneratePackageOnBuild>
-		<Version>17.0.1</Version>
-		<PackageVersion>17.0.1</PackageVersion>
+		<Version>17.1.0</Version>
+		<PackageVersion>17.1.0</PackageVersion>
 		<Authors>Andy Boot, Jeavon</Authors>
 		<Copyright>2026 © Andy Boot</Copyright>
 		<PackageProjectUrl>https://github.com/AndyBoot/Umbraco.Community.ClientDrawer</PackageProjectUrl>

--- a/src/ClientDrawer.Bellissima/Controllers/ClientDrawerController.cs
+++ b/src/ClientDrawer.Bellissima/Controllers/ClientDrawerController.cs
@@ -7,6 +7,7 @@ using Umbraco.Cms.Api.Common.Attributes;
 using Umbraco.Cms.Api.Common.Filters;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Cache;
+using Umbraco.Cms.Core.Security;
 using Umbraco.Cms.Web.Common.Authorization;
 using Umbraco.Cms.Web.Common.Routing;
 using Umbraco.Extensions;
@@ -23,13 +24,15 @@ namespace ClientDrawer.Bellissima.Controllers
     {
         private readonly IClientDrawerService _clientDrawerService;
         private readonly AppCaches _appCaches;
+        private readonly IBackOfficeSecurityAccessor _backOfficeSecurityAccessor;
         private const int CACHE_MINS = 1440; // 1 day
 
 
-        public ClientDrawerController(IClientDrawerService clientDrawerService, AppCaches appCaches)
+        public ClientDrawerController(IClientDrawerService clientDrawerService, AppCaches appCaches, IBackOfficeSecurityAccessor backOfficeSecurityAccessor)
         {
             _clientDrawerService = clientDrawerService;
             _appCaches = appCaches;
+            _backOfficeSecurityAccessor = backOfficeSecurityAccessor;
         }
 
         [HttpGet("getdata")]
@@ -37,7 +40,8 @@ namespace ClientDrawer.Bellissima.Controllers
         [ProducesResponseType(204)]
         public IActionResult GetData()
         {
-            var data = GetSetCacheItem(_clientDrawerService.GetDataWorker, "ClientDrawerGetData", CACHE_MINS);
+            var userId = _backOfficeSecurityAccessor.BackOfficeSecurity?.CurrentUser?.Id ?? 0;
+            var data = GetSetCacheItem(_clientDrawerService.GetDataWorker, $"ClientDrawerGetData_{userId}", CACHE_MINS);
             if (data == null)
             {
                 return NoContent();
@@ -51,7 +55,8 @@ namespace ClientDrawer.Bellissima.Controllers
         [ProducesResponseType(204)]
         public IActionResult GetHeaderActionData()
         {
-            var data = GetSetCacheItem(_clientDrawerService.GetHeaderActionModel, "ClientDrawerGetHeaderActionDataWorker", CACHE_MINS);
+            var userId = _backOfficeSecurityAccessor.BackOfficeSecurity?.CurrentUser?.Id ?? 0;
+            var data = GetSetCacheItem(_clientDrawerService.GetHeaderActionModel, $"ClientDrawerGetHeaderActionDataWorker_{userId}", CACHE_MINS);
             if (data == null)
             {
                 return NoContent();

--- a/src/ClientDrawer.Bellissima/Controllers/ClientDrawerController.cs
+++ b/src/ClientDrawer.Bellissima/Controllers/ClientDrawerController.cs
@@ -19,7 +19,7 @@ namespace ClientDrawer.Bellissima.Controllers
     [Authorize(Policy = AuthorizationPolicies.BackOfficeAccess)]
     [JsonOptionsName(Constants.JsonOptionsNames.BackOffice)]
     [BackOfficeRoute("clientdrawer/api/v{version:apiVersion}")]
-    public class ClientDrawerController
+    public class ClientDrawerController : ControllerBase
     {
         private readonly IClientDrawerService _clientDrawerService;
         private readonly AppCaches _appCaches;
@@ -34,12 +34,30 @@ namespace ClientDrawer.Bellissima.Controllers
 
         [HttpGet("getdata")]
         [ProducesResponseType(typeof(DataModel), 200)]
-        public DataModel? GetData() => GetSetCacheItem(_clientDrawerService.GetDataWorker, "ClientDrawerGetData", CACHE_MINS);
+        [ProducesResponseType(204)]
+        public IActionResult GetData()
+        {
+            var data = GetSetCacheItem(_clientDrawerService.GetDataWorker, "ClientDrawerGetData", CACHE_MINS);
+            if (data == null)
+            {
+                return NoContent();
+            }
+            return new OkObjectResult(data);
+        }
 
 
         [HttpGet("getheaderactiondata")]
         [ProducesResponseType(typeof(HeaderActionModel), 200)]
-        public HeaderActionModel? GetHeaderActionData() => GetSetCacheItem(_clientDrawerService.GetHeaderActionDataWorker, "ClientDrawerGetHeaderActionDataWorker", CACHE_MINS);
+        [ProducesResponseType(204)]
+        public IActionResult GetHeaderActionData()
+        {
+            var data = GetSetCacheItem(_clientDrawerService.GetHeaderActionModel, "ClientDrawerGetHeaderActionDataWorker", CACHE_MINS);
+            if (data == null)
+            {
+                return NoContent();
+            }
+            return new OkObjectResult(data);
+        }
 
         private T? GetSetCacheItem<T>(Func<T> methodName, string cacheName, double expiryMins)
         {

--- a/src/ClientDrawer.Bellissima/NUGET.md
+++ b/src/ClientDrawer.Bellissima/NUGET.md
@@ -9,6 +9,7 @@
     - Website URL
     - Umbraco CMS Url - assumes 'Website URL' + '/umbraco/' by default, but can be manually set if under a different URL. You can disable this all together should you wish.
     - Ability to set additional hostnames
+    - **User Group Permissions** - optionally restrict access to specific environments based on user group membership
     - If the current URL hostname matches the hostname of your Website URL, Umbraco CMS URL or additional hostnames then it will be flagged as 'Current' to clearly identify which environment an editor is on.
 - A client friendly **change log** to share recent developments on the website or platform.
     - Based on your own XML file held within the file system, or as a resource item within an assembly of your choice. 
@@ -50,7 +51,8 @@ Simply search for the `Umbraco.Community.ClientDrawer` NuGet package and add it 
         "Name": "Preview",
         "BaseUrl": "https://preview.samplewebsite.com",
         "AlternativeHostnames": [ "samplewebsite-preview.azurewebsites.net" ],
-        "IconClass": "icon-mindmap"
+        "IconClass": "icon-mindmap",
+        "UserGroups": [ "admin", "editor" ]
       },
       {
         "Name": "Staging",
@@ -113,6 +115,14 @@ Simply search for the `Umbraco.Community.ClientDrawer` NuGet package and add it 
 | DisableUmbracoUrl          	| `bool` 	| `false`  	| | 1.0.0 |
 | AlternativeHostnames          	| `string[]` 	| `null`  	| `["test.samplewebsite.com", "nocache.samplewebsite.com"]` | 1.0.0 |
 | IconClass          	| `string` 	| `"icon-globe"`  	| `"icon-mindmap"` | 1.0.0 |
+| UserGroups          	| `string[]` 	| `null`  	| `["admin", "editor"]` or `["admin"]` | 17.1.0 |
+
+**Note on UserGroups**: 
+- Use a string array of user group aliases (e.g., `["admin", "editor", "writer"]`)
+- If omitted or `null`, the environment is accessible to all backoffice users
+- If specified, only users belonging to one of the listed groups can see that environment
+- If a user has no access to any environments, Client Drawer is automatically hidden
+- Group matching is case-insensitive
 
 ### `ChangeLog`
 
@@ -170,6 +180,7 @@ If you're embedding this file as a resource within a DLL, also use the `ClientDr
 
 |Version    |Change Type    |Description     |
 |-----------|---------------|--------------- |
+|17.1.0     |Feature        |Added UserGroups property to Environment configuration for per-environment access control. Client Drawer automatically hides when users have no accessible environments.|
 |17.0.0     |New release    |Umbraco v17 compatibility|
 |15.0.0.1   |Fix            |Resolved an issue with the Client Drawer Core dependency on first install. Also, Removal of some unnecessary files, thanks [Jeavon](https://github.com/Jeavon)!|
 |15.0.0     |New release    |Compatibility with Umbraco v15|

--- a/src/ClientDrawer.Core/ClientDrawer.Core.csproj
+++ b/src/ClientDrawer.Core/ClientDrawer.Core.csproj
@@ -14,8 +14,8 @@
 		<Description>This is a general dependency of Umbraco.Community.ClientDrawer. You do not need to install this yourself.</Description>
 		<PackageTags>ClientDrawer;Client;Drawer;Changelog;Change;Log;Logs;Environment;Environments;HeaderApp</PackageTags>
 		<GeneratePackageOnBuild>False</GeneratePackageOnBuild>
-		<Version>17.0.1</Version>
-		<PackageVersion>17.0.1</PackageVersion>
+		<Version>17.1.0</Version>
+		<PackageVersion>17.1.0</PackageVersion>
 		<Authors>Andy Boot, Jeavon</Authors>
 		<Copyright>2026 © Andy Boot</Copyright>
 		<PackageProjectUrl>https://github.com/AndyBoot/Umbraco.Community.ClientDrawer</PackageProjectUrl>

--- a/src/ClientDrawer.Core/Models/AppSettingsModel.cs
+++ b/src/ClientDrawer.Core/Models/AppSettingsModel.cs
@@ -26,6 +26,7 @@ namespace ClientDrawer.Core.Models
             public bool DisableUmbracoUrl { get; set; } = false;
             public string[]? AlternativeHostnames { get; set; }
             public string IconClass { get; set; } = "icon-globe";
+            public string? UserGroups { get; set; }
         }
         public record SystemInformationModel
         {

--- a/src/ClientDrawer.Core/Models/AppSettingsModel.cs
+++ b/src/ClientDrawer.Core/Models/AppSettingsModel.cs
@@ -26,7 +26,7 @@ namespace ClientDrawer.Core.Models
             public bool DisableUmbracoUrl { get; set; } = false;
             public string[]? AlternativeHostnames { get; set; }
             public string IconClass { get; set; } = "icon-globe";
-            public string? UserGroups { get; set; }
+            public string[]? UserGroups { get; set; }
         }
         public record SystemInformationModel
         {

--- a/src/ClientDrawer.Core/NUGET.md
+++ b/src/ClientDrawer.Core/NUGET.md
@@ -9,6 +9,7 @@
     - Website URL
     - Umbraco CMS Url - assumes 'Website URL' + '/umbraco/' by default, but can be manually set if under a different URL. You can disable this all together should you wish.
     - Ability to set additional hostnames
+    - **User Group Permissions** - optionally restrict access to specific environments based on user group membership
     - If the current URL hostname matches the hostname of your Website URL, Umbraco CMS URL or additional hostnames then it will be flagged as 'Current' to clearly identify which environment an editor is on.
 - A client friendly **change log** to share recent developments on the website or platform.
     - Based on your own XML file held within the file system, or as a resource item within an assembly of your choice. 
@@ -50,7 +51,8 @@ Simply search for the `Umbraco.Community.ClientDrawer` NuGet package and add it 
         "Name": "Preview",
         "BaseUrl": "https://preview.samplewebsite.com",
         "AlternativeHostnames": [ "samplewebsite-preview.azurewebsites.net" ],
-        "IconClass": "icon-mindmap"
+        "IconClass": "icon-mindmap",
+        "UserGroups": [ "admin", "editor" ]
       },
       {
         "Name": "Staging",
@@ -113,6 +115,14 @@ Simply search for the `Umbraco.Community.ClientDrawer` NuGet package and add it 
 | DisableUmbracoUrl          	| `bool` 	| `false`  	| | 1.0.0 |
 | AlternativeHostnames          	| `string[]` 	| `null`  	| `["test.samplewebsite.com", "nocache.samplewebsite.com"]` | 1.0.0 |
 | IconClass          	| `string` 	| `"icon-globe"`  	| `"icon-mindmap"` | 1.0.0 |
+| UserGroups          	| `string[]` 	| `null`  	| `["admin", "editor"]` or `["admin"]` | 17.1.0 |
+
+**Note on UserGroups**: 
+- Use a string array of user group aliases (e.g., `["admin", "editor", "writer"]`)
+- If omitted or `null`, the environment is accessible to all backoffice users
+- If specified, only users belonging to one of the listed groups can see that environment
+- If a user has no access to any environments, Client Drawer is automatically hidden
+- Group matching is case-insensitive
 
 ### `ChangeLog`
 
@@ -170,6 +180,7 @@ If you're embedding this file as a resource within a DLL, also use the `ClientDr
 
 |Version    |Change Type    |Description     |
 |-----------|---------------|--------------- |
+|17.1.0     |Feature        |Added UserGroups property to Environment configuration for per-environment access control. Client Drawer automatically hides when users have no accessible environments.|
 |17.0.0     |New release    |Umbraco v17 compatibility|
 |15.0.0.1   |Fix            |Resolved an issue with the Client Drawer Core dependency on first install. Also, Removal of some unnecessary files, thanks [Jeavon](https://github.com/Jeavon)!|
 |15.0.0     |New release    |Compatibility with Umbraco v15|

--- a/src/ClientDrawer.Core/Services/ClientDrawerService.cs
+++ b/src/ClientDrawer.Core/Services/ClientDrawerService.cs
@@ -54,17 +54,13 @@ namespace ClientDrawer.Core.Services
                 .Where(env =>
                 {
                     // If no UserGroups specified, environment is accessible to all
-                    if (string.IsNullOrWhiteSpace(env.UserGroups))
+                    if (env.UserGroups == null || env.UserGroups.Length == 0)
                         return true;
 
-                    // Parse comma-separated user groups
-                    var allowedGroups = env.UserGroups
-                        .Split(',', StringSplitOptions.RemoveEmptyEntries)
+                    // Check if user is in any of the allowed groups (trim for consistency)
+                    return env.UserGroups
                         .Select(g => g.Trim())
-                        .ToList();
-
-                    // Check if user is in any of the allowed groups
-                    return allowedGroups.Any(g => userGroupAliases.Contains(g, StringComparer.OrdinalIgnoreCase));
+                        .Any(g => userGroupAliases.Contains(g, StringComparer.OrdinalIgnoreCase));
                 })
                 .Select(x => new EnvironmentModel(
                     x.Name,

--- a/src/ClientDrawer.Core/Services/ClientDrawerService.cs
+++ b/src/ClientDrawer.Core/Services/ClientDrawerService.cs
@@ -11,13 +11,14 @@ using ClientDrawer.Core.Enums;
 using Umbraco.Extensions;
 using Umbraco.Cms.Core.Cache;
 using Microsoft.AspNetCore.Mvc;
+using Umbraco.Cms.Core.Security;
 
 namespace ClientDrawer.Core.Services
 {
     public interface IClientDrawerService
     {
-        DataModel GetDataWorker();
-        HeaderActionModel GetHeaderActionDataWorker();
+        DataModel? GetDataWorker();
+        HeaderActionModel? GetHeaderActionModel();
     }
 
     public class ClientDrawerService : IClientDrawerService
@@ -25,28 +26,68 @@ namespace ClientDrawer.Core.Services
         private readonly AppSettingsModel _options;
         private readonly IWebHostEnvironment _env;
         private Uri _currentUri;
-        private List<EnvironmentModel> _environmentModels;
         private readonly IWebHostEnvironment _webHostEnvironment;
+        private readonly IBackOfficeSecurityAccessor _backOfficeSecurityAccessor;
 
-        public ClientDrawerService(IOptions<AppSettingsModel> options, IWebHostEnvironment env, IHttpContextAccessor httpContextAccessor, IWebHostEnvironment webHostEnvironment)
+        public ClientDrawerService(IOptions<AppSettingsModel> options, IWebHostEnvironment env, IHttpContextAccessor httpContextAccessor, IWebHostEnvironment webHostEnvironment, IBackOfficeSecurityAccessor backOfficeSecurityAccessor)
         {
             _options = options.Value;
             _env = env;
             _currentUri = new(httpContextAccessor.HttpContext?.Request.GetDisplayUrl() ?? throw new Exception("Unable to capture current request URL"));
-            _environmentModels = _options.Environments?.Select(x => new EnvironmentModel(x.Name,
-                                                                                       new Uri(x.BaseUrl),
-                                                                                       _currentUri,
-                                                                                       x.UmbracoPathOrUrl,
-                                                                                       x.DisableUmbracoUrl,
-                                                                                       x.AlternativeHostnames,
-                                                                                       x.IconClass)).ToList()
-
-                                                                                       ?? Enumerable.Empty<EnvironmentModel>().ToList();
             _webHostEnvironment = webHostEnvironment;
+            _backOfficeSecurityAccessor = backOfficeSecurityAccessor;
         }
 
-        public DataModel GetDataWorker()
+        private List<EnvironmentModel> GetFilteredEnvironmentModels()
         {
+            if (_options.Environments == null || !_options.Environments.Any())
+            {
+                return new List<EnvironmentModel>();
+            }
+
+            // Get current user's group aliases
+            var currentUser = _backOfficeSecurityAccessor.BackOfficeSecurity?.CurrentUser;
+            var userGroupAliases = currentUser?.Groups.Select(g => g.Alias).ToList() ?? new List<string>();
+
+            // Filter environments based on user groups
+            var filteredEnvironments = _options.Environments
+                .Where(env =>
+                {
+                    // If no UserGroups specified, environment is accessible to all
+                    if (string.IsNullOrWhiteSpace(env.UserGroups))
+                        return true;
+
+                    // Parse comma-separated user groups
+                    var allowedGroups = env.UserGroups
+                        .Split(',', StringSplitOptions.RemoveEmptyEntries)
+                        .Select(g => g.Trim())
+                        .ToList();
+
+                    // Check if user is in any of the allowed groups
+                    return allowedGroups.Any(g => userGroupAliases.Contains(g, StringComparer.OrdinalIgnoreCase));
+                })
+                .Select(x => new EnvironmentModel(
+                    x.Name,
+                    new Uri(x.BaseUrl),
+                    _currentUri,
+                    x.UmbracoPathOrUrl,
+                    x.DisableUmbracoUrl,
+                    x.AlternativeHostnames,
+                    x.IconClass))
+                .ToList();
+
+            return filteredEnvironments;
+        }
+
+        public DataModel? GetDataWorker()
+        {
+            var environmentModels = GetFilteredEnvironmentModels();
+
+            // If user has no accessible environments, return null
+            if (!environmentModels.Any())
+            {
+                return null;
+            }
             string heading = _options.ClientName;
             string platformAssemblyName = _options.Platform?.AssemblyName ?? "";
             string platformAssemblyVersion = GetAssemblyVersion(platformAssemblyName, _options.Platform?.VersionSource, _options.Platform?.VersionRegEx);
@@ -56,7 +97,7 @@ namespace ClientDrawer.Core.Services
             {
                 Heading = heading,
                 PrimaryAssembly = new AssemblyModel(platformAssemblyName, platformAssemblyVersion),
-                Environments = _environmentModels,
+                Environments = environmentModels,
                 SystemInformation = new()
                 {
                     Enabled = _options.SystemInformation.Enabled,
@@ -69,15 +110,26 @@ namespace ClientDrawer.Core.Services
             return dataModel;
         }
 
-        public HeaderActionModel GetHeaderActionDataWorker() => new()
+        public HeaderActionModel? GetHeaderActionModel()
         {
-            ClientName = _options.ClientName,
-            IconClass = _options.IconClass,
-            IconImageFilePath = _options.IconImageFilePath,
-            HeaderButtonMode = _options.HeaderButtonMode.ToString(),
-            CurrentEnvironmentName = _environmentModels.FirstOrDefault(x => x.IsCurrent)?.Name ?? "Unknown Environment",
-            IconSVG = ReadSvgFile(_options.IconImageFilePath)
-        };
+            var environmentModels = GetFilteredEnvironmentModels();
+
+            // If user has no accessible environments, return null
+            if (!environmentModels.Any())
+            {
+                return null;
+            }
+
+            return new HeaderActionModel
+            {
+                ClientName = _options.ClientName,
+                IconClass = _options.IconClass,
+                IconImageFilePath = _options.IconImageFilePath,
+                HeaderButtonMode = _options.HeaderButtonMode.ToString(),
+                CurrentEnvironmentName = environmentModels.FirstOrDefault(x => x.IsCurrent)?.Name ?? "Unknown Environment",
+                IconSVG = ReadSvgFile(_options.IconImageFilePath)
+            };
+        }
 
         private static string GetAssemblyVersion(string assemblyName, AssemblyVersionEnum? versionSource, string? versionRegEx = null)
         {

--- a/src/ClientDrawer.Website.v17.Initial/appsettings.json
+++ b/src/ClientDrawer.Website.v17.Initial/appsettings.json
@@ -58,21 +58,21 @@
         "BaseUrl": "https://preview.samplewebsite.com",
         "AlternativeHostnames": [ "samplewebsite-preview.azurewebsites.net" ],
         "IconClass": "icon-mindmap",
-        "UserGroups": "admin,editor"
+        "UserGroups": [ "admin", "editor" ]
       },
       {
         "Name": "Staging",
         "BaseUrl": "https://staging.samplewebsite.com",
         "UmbracoPathOrUrl": "https://samplewebsite-staging.azurewebsites.net/umbraco/",
         "IconClass": "icon-presentation",
-        "UserGroups": "admin,editor"
+        "UserGroups": [ "admin", "editor" ]
       },
       {
         "Name": "Authoring",
         "BaseUrl": "https://authoring.samplewebsite.com",
         "UmbracoPathOrUrl": "https://samplewebsite-authoring.azurewebsites.net/umbraco/",
         "IconClass": "icon-keyboard",
-        "UserGroups": "admin,editor"
+        "UserGroups": [ "admin", "editor" ]
       },
       {
         "Name": "Production",

--- a/src/ClientDrawer.Website.v17.Initial/appsettings.json
+++ b/src/ClientDrawer.Website.v17.Initial/appsettings.json
@@ -57,19 +57,22 @@
         "Name": "Preview",
         "BaseUrl": "https://preview.samplewebsite.com",
         "AlternativeHostnames": [ "samplewebsite-preview.azurewebsites.net" ],
-        "IconClass": "icon-mindmap"
+        "IconClass": "icon-mindmap",
+        "UserGroups": "admin,editor"
       },
       {
         "Name": "Staging",
         "BaseUrl": "https://staging.samplewebsite.com",
         "UmbracoPathOrUrl": "https://samplewebsite-staging.azurewebsites.net/umbraco/",
-        "IconClass": "icon-presentation"
+        "IconClass": "icon-presentation",
+        "UserGroups": "admin,editor"
       },
       {
         "Name": "Authoring",
         "BaseUrl": "https://authoring.samplewebsite.com",
         "UmbracoPathOrUrl": "https://samplewebsite-authoring.azurewebsites.net/umbraco/",
-        "IconClass": "icon-keyboard"
+        "IconClass": "icon-keyboard",
+        "UserGroups": "admin,editor"
       },
       {
         "Name": "Production",

--- a/src/pack.ps1
+++ b/src/pack.ps1
@@ -6,8 +6,8 @@ Set-Location -Path $outputDir
 
 # List of projects and their respective versions
 $projectVersions = @{
-    "ClientDrawer.Bellissima" = "17.0.1"
-    "ClientDrawer.Core" = "17.0.1"
+    "ClientDrawer.Bellissima" = "17.1.0"
+    "ClientDrawer.Core" = "17.1.0"
 }
 
 # Extract the version of ClientDrawer.Core


### PR DESCRIPTION
Environments can now be configured with a `UserGroups` property in `appsettings.json`, allowing administrators to specify which Umbraco back-office user groups can see a particular environment.
This pull request introduces per-environment access control to the Client Drawer feature by adding a `UserGroups` property to environment configuration. Now, environments can be restricted so only users in specified backoffice user groups can see them. If a user has no access to any environments, the Client Drawer is hidden entirely. The changes also refactor the API to return `204 No Content` when no environments are available, and update documentation and sample configuration accordingly.

**Feature: Per-environment access control**
- Added a `UserGroups` property to the environment configuration (`EnvironmentModel` and `appsettings.json`), allowing environments to be shown only to users in specified user groups. Group matching is case-insensitive and comma-separated. [[1]](diffhunk://#diff-01f58e13f0b21a839091956bc5be5090accb705b1e1a830f5cef12f7d5c3380cR29) [[2]](diffhunk://#diff-a1630ddf38ed5f9d84dbb6e094c35c6cafff958497b022e070cf0d10591f6527L60-R75)
- Updated the service layer (`ClientDrawerService`) to filter environments based on the current user's group membership. If no environments are accessible, `null` is returned and the Client Drawer is hidden. [[1]](diffhunk://#diff-4298fb25207d736c5f0753dbc73f47e1fb0b0f3cdb0751da48f9cf75d3cd528aR14-R90) [[2]](diffhunk://#diff-4298fb25207d736c5f0753dbc73f47e1fb0b0f3cdb0751da48f9cf75d3cd528aL59-R100) [[3]](diffhunk://#diff-4298fb25207d736c5f0753dbc73f47e1fb0b0f3cdb0751da48f9cf75d3cd528aL72-R132)

**API changes**
- Controller action methods now return `IActionResult` and respond with `204 No Content` when no environments are available for the user, instead of returning `null` data. [[1]](diffhunk://#diff-7e425e6b2c0c4b98f2cbfc7702058faeb1c008f74ff86520a8a9b4c5166a7b1dL22-R22) [[2]](diffhunk://#diff-7e425e6b2c0c4b98f2cbfc7702058faeb1c008f74ff86520a8a9b4c5166a7b1dL37-R60)

**Documentation updates**
- Updated `README.md` to describe the new `UserGroups` feature, how to configure it, and its behavior. Added a note to the configuration table and a new entry in the changelog. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R12) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L53-R55) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R118-R125) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R183)
- Updated sample `appsettings.json` to demonstrate use of the `UserGroups` property for environments.

These changes provide more granular control over environment visibility in the Client Drawer, improving security and user experience.
- If `UserGroups` is defined for an environment, only users belonging to at least one of those groups will see it.
- If `UserGroups` is not set, the environment remains visible to all users.
- The `GetData` and `GetHeaderActionData` API endpoints now return an HTTP 204 No Content response if no environments are accessible to the current user, rather than an empty 200 OK.
- This change necessitated the `ClientDrawerController` to inherit from `ControllerBase` and its actions to return `IActionResult` to properly handle HTTP responses.

This PR will close #6